### PR TITLE
Don't reconfirm already acked messages when multiple is true. Fixes #615

### DIFF
--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1789,7 +1789,7 @@ module Bunny
     # @private
     def handle_ack_or_nack(delivery_tag_before_offset, multiple, nack)
       delivery_tag          = delivery_tag_before_offset + @delivery_tag_offset
-      confirmed_range_start = multiple ? @delivery_tag_offset + 1 : delivery_tag
+      confirmed_range_start = multiple ? @delivery_tag_offset + @unconfirmed_set.first : delivery_tag
       confirmed_range_end   = delivery_tag
       confirmed_range       = (confirmed_range_start..confirmed_range_end)
 

--- a/lib/bunny/channel.rb
+++ b/lib/bunny/channel.rb
@@ -1789,7 +1789,7 @@ module Bunny
     # @private
     def handle_ack_or_nack(delivery_tag_before_offset, multiple, nack)
       delivery_tag          = delivery_tag_before_offset + @delivery_tag_offset
-      confirmed_range_start = multiple ? @delivery_tag_offset + @unconfirmed_set.first : delivery_tag
+      confirmed_range_start = multiple ? @delivery_tag_offset + @unconfirmed_set.min : delivery_tag
       confirmed_range_end   = delivery_tag
       confirmed_range       = (confirmed_range_start..confirmed_range_end)
 

--- a/spec/issues/issue615_spec.rb
+++ b/spec/issues/issue615_spec.rb
@@ -31,7 +31,7 @@ describe 'multiple atribute handling on acks' do
       attr_accessor :multiples, :old_implementation
 
       def handle_ack_or_nack(delivery_tag_before_offset, multiple, nack)
-        range_start_testing = old_implementation ? 1 : @unconfirmed_set.first # choose between subsets
+        range_start_testing = old_implementation ? 1 : @unconfirmed_set.min # choose between subsets
 
         delivery_tag          = delivery_tag_before_offset + @delivery_tag_offset
         confirmed_range_start = multiple ? @delivery_tag_offset + range_start_testing : delivery_tag

--- a/spec/issues/issue615_spec.rb
+++ b/spec/issues/issue615_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'multiple atribute handling on acks' do
+  # Monkey patch with 2 implementations of confirmed subsets + counters for testing
+  class Bunny::Channel
+    attr_accessor :multiples, :old_implementation
+
+    def handle_ack_or_nack(delivery_tag_before_offset, multiple, nack)
+      range_start_testing = old_implementation ? 1 : @unconfirmed_set.first # choose between subsets
+
+      delivery_tag          = delivery_tag_before_offset + @delivery_tag_offset
+      confirmed_range_start = multiple ? @delivery_tag_offset + range_start_testing : delivery_tag
+      confirmed_range_end   = delivery_tag
+      confirmed_range       = (confirmed_range_start..confirmed_range_end)
+
+      # just counting multiples to proof we recieved some
+      @multiples = @multiples.to_i + 1 if multiple
+
+      @unconfirmed_set_mutex.synchronize do
+        if nack
+          @nacked_set.merge(@unconfirmed_set & confirmed_range)
+        end
+
+        @unconfirmed_set.subtract(confirmed_range)
+
+        @only_acks_received = (@only_acks_received && !nack)
+
+        @confirms_continuations.push(true) if @unconfirmed_set.empty?
+
+        if @confirms_callback
+          confirmed_range.each do |tag|
+            @confirms_callback.call(tag, false, nack)
+          end
+        end
+      end
+    end
+  end
+
+  def measure
+    result = {}
+    result[:begin] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield(result)
+  rescue => e
+    result[:exception] = e
+  ensure
+    result[:end] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result[:duration] = (result[:end] - result[:begin]).round(2)
+    return result
+  end
+
+  before(:all) do
+    @connection = Bunny.new(username: 'bunny_gem',
+                            password: 'bunny_password',
+                            vhost: 'bunny_testbed',
+                            automatic_recovery: false,
+                            write_timeout: 0,
+                            read_timeout: 0)
+    @connection.start
+  end
+
+  after(:all) do
+    @connection.close if @connection.open?
+  end
+
+  let(:messages) { 10_000 }
+  let(:channel) { @connection.create_channel }
+  let(:queue) { channel.queue('bunny.basic.ack.multiple-acks', auto_delete: true) }
+
+  context 'when multiple atribute used' do
+    it 'faster with new implementation' do
+      queue.subscribe(manual_ack: false)
+
+      channel.confirm_select
+
+      old = measure do
+        channel.old_implementation = true
+        exchange = channel.default_exchange
+
+        messages.times do
+          exchange.publish('small message', routing_key: queue.name)
+        end
+
+        channel.wait_for_confirms
+
+        expect(channel.multiples).to be >= 1
+      end
+      puts "Old implementation duration: #{old[:duration]} seconds"
+
+      channel.multiples = 0 # clean up
+
+      new = measure do
+        channel.old_implementation = false
+        exchange = channel.default_exchange
+
+        messages.times do
+          exchange.publish('small message', routing_key: queue.name)
+        end
+
+        channel.wait_for_confirms
+
+        expect(channel.multiples).to be >= 1
+      end
+      puts "New implementation duration: #{new[:duration]} seconds"
+
+      expect(new[:duration]).to be < old[:duration]
+    end
+  end
+end


### PR DESCRIPTION
In [current implementation ](https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/channel.rb#L1792) library acks all tags starting from tag **1** (plus channel recovery offset) every time it gets `multiple` flag regardless of previously acknowledged tags. So when `multiple` flag occured ex. at delivery_tag 1000 (after 990 aked), we receive `confirm_select callback` 1000 times. And we receive this call callback again and again (hudren thousands times) while processing just 16k messages.

After some research of other language implementation ([java](https://github.com/rabbitmq/rabbitmq-java-client/blob/394d8968d8babe64c15357d53debfe3aacfbbf24/src/main/java/com/rabbitmq/client/impl/ChannelN.java#L1604) and [python](https://github.com/pika/pika/blob/1baf475547351c4f37762c5534de9ac49affed3d/pika/adapters/twisted_connection.py#L715)) we made a little fix to resolve this issue. [RabbitMQ protocol extension](https://www.rabbitmq.com/confirms.html#publisher-confirms) strgongly enforces sequenced delivery_tag generation on publishing. There is `@unconfirmed_set` filled with not-yet-acked tags (previously acked tags already removed from it) so we just need to ack tags from first (smallest) unconfirmed position till currentlry delivered with `multiple` flag to fit RabbitMQ publisher confirms protocol extension. 

There is additional test case to test and compare old and new behaviour. It is not for enclusion in resulting PR - just for experiments.  You can change messages count to higher value when **difference increased drastically**.
